### PR TITLE
Set Default Blaze Log Level to Info

### DIFF
--- a/server/blaze/docker-compose.yml
+++ b/server/blaze/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     restart: unless-stopped
     environment:
       BASE_URL: "http://localhost:8082"
-      LOG_LEVEL: ${BLAZE_LOG_LEVEL:-error}
+      LOG_LEVEL: ${BLAZE_LOG_LEVEL:-info}
       JAVA_TOOL_OPTIONS: ${BLAZE_JVM_ARGS:--Xmx4g}
       DB_BLOCK_CACHE_SIZE: ${BLAZE_BLOCK_CACHE_SIZE:-256}
       DB_RESOURCE_CACHE_SIZE: ${BLAZE_DB_RESOURCE_CACHE_SIZE:-2000000}


### PR DESCRIPTION
With error log-level one doesn't see at which point Blaze ist started successfully. Also with info Blaze doesn't log every request. So it is save to set the level to info.